### PR TITLE
BZ 825114: Add nodejs-0.6 as a builder type

### DIFF
--- a/src/main/resources/hudson/plugins/openshift/OpenShiftBuilderTypeJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/openshift/OpenShiftBuilderTypeJobProperty/config.jelly
@@ -4,6 +4,7 @@ xmlns:f="/lib/form">
     <f:entry name="builderType" title="Builder Type" field="builderType">
         <select name="builderType">
             <f:option value="diy-0.1" selected="${instance.builderType=='diy-0.1'}">diy-0.1</f:option>
+            <f:option value="nodejs-0.6" selected="${instance.builderType=='nodejs-0.6'}">nodejs-0.6</f:option>
             <f:option value="jbossas-7" selected="${instance.builderType=='jbossas-7'}">jbossas-7</f:option>
             <f:option value="php-5.3" selected="${instance.builderType=='php-5.3'}">php-5.3</f:option>
             <f:option value="perl-5.10" selected="${instance.builderType=='perl-5.10'}">perl-5.10</f:option>


### PR DESCRIPTION
Low priority request to add nodejs-0.6 as a builder type.
