### PR TITLE
Bug 924203 - Forcing the jenkins cloud plugin to read the broker auth to...

### DIFF
--- a/src/main/java/hudson/plugins/openshift/OpenShiftCloud.java
+++ b/src/main/java/hudson/plugins/openshift/OpenShiftCloud.java
@@ -222,18 +222,14 @@ public final class OpenShiftCloud extends Cloud {
 	}
 
 	private String getBrokerAuthKey() throws IOException {
-		if (brokerAuthKey == null) {
-			String homeDir = System.getenv("HOME");
-			brokerAuthKey = fileToString(homeDir + "/.auth/token");
-		}
+		String homeDir = System.getenv("HOME");
+		brokerAuthKey = fileToString(homeDir + "/.auth/token");
 		return brokerAuthKey;
 	}
 
 	private String getBrokerAuthIV() throws IOException {
-		if (brokerAuthIV == null) {
-			String homeDir = System.getenv("HOME");
-			brokerAuthIV = fileToString(homeDir + "/.auth/iv");
-		}
+		String homeDir = System.getenv("HOME");
+		brokerAuthIV = fileToString(homeDir + "/.auth/iv");
 		return brokerAuthIV;
 	}
 


### PR DESCRIPTION
...ken from disk

Otherwise the cached values will break whenever tokens are rekeyed.
