### PR TITLE
Make builderType free-form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 work
+*.iml
+*.sublime*
+.settings
+

--- a/src/main/resources/hudson/plugins/openshift/OpenShiftBuilderTypeJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/openshift/OpenShiftBuilderTypeJobProperty/config.jelly
@@ -2,21 +2,6 @@
 xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 xmlns:f="/lib/form">
     <f:entry name="builderType" title="Builder Type" field="builderType">
-        <select name="builderType">
-            <f:option value="diy-0.1" selected="${instance.builderType=='diy-0.1'}">diy-0.1</f:option>
-            <f:option value="nodejs-0.6" selected="${instance.builderType=='nodejs-0.6'}">nodejs-0.6</f:option>
-            <f:option value="jbosseap-6.0" selected="${instance.builderType=='jbosseap-6.0'}">jbosseap-6.0</f:option>
-            <f:option value="jbossas-7" selected="${instance.builderType=='jbossas-7'}">jbossas-7</f:option>
-            <f:option value="php-5.3" selected="${instance.builderType=='php-5.3'}">php-5.3</f:option>
-            <f:option value="perl-5.10" selected="${instance.builderType=='perl-5.10'}">perl-5.10</f:option>
-            <f:option value="ruby-1.8" selected="${instance.builderType=='ruby-1.8'}">ruby-1.8</f:option>
-            <f:option value="ruby-1.9" selected="${instance.builderType=='ruby-1.9'}">ruby-1.9</f:option>
-            <f:option value="python-2.6" selected="${instance.builderType=='python-2.6'}">python-2.6</f:option>
-            <f:option value="python-2.7" selected="${instance.builderType=='python-2.7'}">python-2.7</f:option>
-            <f:option value="python-3.3" selected="${instance.builderType=='python-3.3'}">python-3.3</f:option>
-            <f:option value="zend-5.6" selected="${instance.builderType=='zend-5.6'}">zend-5.6</f:option>
-            <f:option value="jbossews-1.0" selected="${instance.builderType=='jbossews-1.0'}">jbossews-1.0</f:option>
-            <f:option value="jbossews-2.0" selected="${instance.builderType=='jbossews-2.0'}">jbossews-2.0</f:option>
-        </select>
+        <f:textbox field="builderType" default="diy-0.1" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
The builderType property will soon be removed from the plugin; To facilitate
that change, make the field free-form to easy the path to v2 cartridge support
which requires the versions be easily updatable and not hard-coded in the
dropdown list.
