### PR TITLE
Urls with dashes

### DIFF
--- a/src/main/java/hudson/plugins/openshift/OpenShiftComputerLauncher.java
+++ b/src/main/java/hudson/plugins/openshift/OpenShiftComputerLauncher.java
@@ -142,6 +142,9 @@ public class OpenShiftComputerLauncher extends ComputerLauncher {
         StringTokenizer tokenizer = new StringTokenizer(hostname, "-");
         tokenizer.nextToken();
         String currentDns = tokenizer.nextToken();
+        while (tokenizer.hasMoreTokens()) {
+            currentDns = currentDns + "-" + tokenizer.nextToken();
+        }
         String gearDns = System.getenv("OPENSHIFT_GEAR_DNS");
         tokenizer = new StringTokenizer(gearDns, "-");
         currentDns = tokenizer.nextToken() + "-" + currentDns;


### PR DESCRIPTION
If your OpenShift url contains a - (eg: openshift-test.internal.openshift.com) then Jenkins errors out when trying to run a build. (see: https://bugzilla.redhat.com/show_bug.cgi?id=984608 )

This patch allows the build to proceed.
