### PR TITLE
Set downloadable cartridge name when creating builder app

### DIFF
--- a/src/main/java/hudson/plugins/openshift/OpenShiftCloud.java
+++ b/src/main/java/hudson/plugins/openshift/OpenShiftCloud.java
@@ -375,7 +375,9 @@ public final class OpenShiftCloud extends Cloud {
 
                 OpenShiftPlatformJobProperty ospjp = ((OpenShiftPlatformJobProperty) job
                         .getProperty(OpenShiftPlatformJobProperty.class));
-                builderPlatform = ospjp.platform;
+                if(ospjp!=null) {
+                    builderPlatform = ospjp.platform;
+                }
 
                 OpenShiftBuilderTimeoutJobProperty timeoutJobProperty = ((OpenShiftBuilderTimeoutJobProperty) job
                         .getProperty(OpenShiftBuilderTimeoutJobProperty.class));

--- a/src/main/java/hudson/plugins/openshift/OpenShiftSlave.java
+++ b/src/main/java/hudson/plugins/openshift/OpenShiftSlave.java
@@ -120,7 +120,7 @@ public class OpenShiftSlave extends AbstractCloudSlave {
             }
             if(baseApp.getCartridge().getUrl()!=null) {
                 // downloadable cartridge
-                return new StandaloneCartridge(null, baseApp.getCartridge().getUrl());
+                return new StandaloneCartridge(baseApp.getCartridge().getName(), baseApp.getCartridge().getUrl());
             } else {
                 // cartridge from repository
                 String cartridgeType=baseApp.getCartridge().getName();


### PR DESCRIPTION
also default to linux platform if builder job does not specify a platform, for backwards compatibility.
